### PR TITLE
Set up development environment (bun) + AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,26 @@
+# AGENTS.md
+
+See `CLAUDE.md` for the full architecture overview and command reference. This is a React Router v7 app deployed on Cloudflare Workers (D1 SQLite, R2, better-auth) for taloranderson.com.
+
+## Cursor Cloud specific instructions
+
+### Package manager / tooling
+
+- This repo uses **bun** (not npm), per `bun.lock` and `CLAUDE.md`. Bun is installed at `~/.bun/bin` and on `PATH` via `~/.bashrc`. If a non-interactive shell can't find `bun`, invoke it as `~/.bun/bin/bun`.
+- Dependencies are installed by the startup update script (`bun install`). The `postinstall` step runs `wrangler types`, which regenerates `worker-configuration.d.ts` (this file and `bun.lock` may show as modified after install — these are generated, don't commit incidental changes).
+
+### Local database (required before app DB features work)
+
+- The local D1 database lives in `.wrangler/state` (gitignored). Run `bun run db:migrate` to apply migrations to the local D1 before using DB-backed features (blog, auth). This is intentionally NOT in the update script.
+
+### Running the app
+
+- Dev server: `bun run dev` → http://localhost:5173 (HMR). This is the dev workflow; do not use `bun run deploy`/production for local work.
+- This is a **single-user** blog: `/signup` only works to create the _first_ user. Once a user exists, registration is disabled and you must use `/login`. Creating/editing posts (`/blog/new`, `/blog/:id/edit`) requires being logged in.
+
+### Tests / checks
+
+- Unit tests (vitest): `bunx vitest run` (matches `app/**/*.test.ts`).
+- E2E tests (Playwright): `bun run test`. Requires the chromium browser (`bunx playwright install --with-deps chromium`); Playwright auto-starts the dev server via its `webServer` config and reuses an already-running one on :5173.
+- Typecheck: `bun run typecheck`. Note: there are two **pre-existing** type errors in `app/routes/images.tsx` unrelated to environment setup.
+- There is no lint script; `bun run format` runs Prettier.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this React Router v7 + Cloudflare Workers (D1/R2/better-auth) app and documents non-obvious startup caveats for future cloud agents.

- Installed **bun** (the repo's package manager per `bun.lock`/`CLAUDE.md`) and project dependencies.
- Configured the startup update script to `bun install` (the `postinstall` regenerates `worker-configuration.d.ts`).
- Added `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering the package manager, local D1 migration step, dev server, the single-user signup caveat, and how to run tests/typecheck.

No application code was modified.

## Environment verification

| Step | Command | Result |
|------|---------|--------|
| Install deps | `bun install` | pass |
| Local DB migrations | `bun run db:migrate` | pass (6 migrations) |
| Unit tests | `bunx vitest run` | pass (27/27) |
| E2E tests | `bun run test` | pass (6/6 Playwright) |
| Build | `bun run build` | pass |
| Dev server | `bun run dev` | serves http://localhost:5173 |
| Typecheck | `bun run typecheck` | 2 pre-existing errors in `app/routes/images.tsx` (unrelated to setup) |

## Hello-world walkthrough

Logged in, created a new blog post draft, filled title/body, published it, and confirmed it renders in the blog list and on its own page. Verified the row persisted in local D1.

[blog_create_publish_demo.mp4](https://cursor.com/agents/bc-503dee6a-1ca8-4921-80ee-18e2b6166354/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_create_publish_demo.mp4)

[Published post rendered](https://cursor.com/agents/bc-503dee6a-1ca8-4921-80ee-18e2b6166354/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_post_rendered.webp)
[Blog list with new post](https://cursor.com/agents/bc-503dee6a-1ca8-4921-80ee-18e2b6166354/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_list.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-503dee6a-1ca8-4921-80ee-18e2b6166354"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-503dee6a-1ca8-4921-80ee-18e2b6166354"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

