### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Typecheck, test, and build
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Apply database migrations
+        run: bun run db:migrate
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Unit tests
+        run: bunx vitest run
+
+      - name: Build
+        run: bun run build
+
+      - name: Install Playwright browser
+        run: bunx playwright install --with-deps chromium
+
+      - name: E2E tests
+        run: bun run test

--- a/app/routes/images.tsx
+++ b/app/routes/images.tsx
@@ -79,8 +79,8 @@ export default function Images({ loaderData }: Route.ComponentProps) {
     return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + " " + sizes[i];
   };
 
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString();
+  const formatDate = (date: Date | string) => {
+    return new Date(date).toLocaleDateString();
   };
 
   return (
@@ -110,10 +110,6 @@ export default function Images({ loaderData }: Route.ComponentProps) {
             display: "grid",
             gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))",
             gap: "30px",
-            "@media (max-width: 640px)": {
-              gridTemplateColumns: "1fr",
-              gap: "20px",
-            },
           }}
         >
           {images.map((image) => (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a GitHub Actions workflow that runs on pushes to `main` and on all pull requests.

The CI job runs:

- **Typecheck** (`bun run typecheck`)
- **Unit tests** (`bunx vitest run`)
- **Production build** (`bun run build`)
- **E2E tests** (`bun run test` with Playwright)

It also applies local D1 migrations before E2E tests so the dev server has a working database.

## Additional changes

Fixed two pre-existing TypeScript errors in `app/routes/images.tsx` so typecheck passes in CI:

- Removed an invalid `@media` query from inline styles (not supported in React `style` objects)
- Updated `formatDate` to accept `Date | string` to match R2 object metadata types

## Test plan

- [x] `bun run typecheck` passes locally
- [x] `bunx vitest run` passes locally
- [x] `bun run build` passes locally
- [x] `CI=true bun run test` passes locally
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3bee4b76-d8c6-42c5-93f5-5642636b99bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3bee4b76-d8c6-42c5-93f5-5642636b99bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

