### PR TITLE
Migrate images page to CSS modules

### DIFF
--- a/app/routes/images.module.css
+++ b/app/routes/images.module.css
@@ -1,0 +1,123 @@
+.main {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+.header {
+  margin-bottom: 40px;
+}
+
+.backLinkWrapper {
+  margin-bottom: 20px;
+}
+
+.backLink {
+  text-decoration: none;
+  color: var(--dimmer-color);
+  font-size: 14px;
+}
+
+.title {
+  margin: 0 0 10px;
+}
+
+.subtitle {
+  margin: 0;
+  color: var(--dimmer-color);
+}
+
+.empty {
+  color: var(--dimmer-color);
+  text-align: center;
+  margin-top: 60px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 30px;
+}
+
+@media (max-width: 640px) {
+  .grid {
+    grid-template-columns: 1fr;
+    gap: 20px;
+  }
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.imageButton {
+  aspect-ratio: 1;
+  border-radius: 8px;
+  overflow: hidden;
+  cursor: pointer;
+  border: 1px solid #e5e5e5;
+  transition: transform 0.1s ease;
+  position: relative;
+}
+
+.imageButton:active {
+  transform: scale(0.98);
+}
+
+.image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.copiedOverlay {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: rgba(0, 0, 0, 0.8);
+  color: white;
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-size: 12px;
+}
+
+.meta {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.filenameButton {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+  font-size: 14px;
+  font-weight: 500;
+  color: #333;
+  text-decoration: underline;
+  text-decoration-color: transparent;
+  transition: all 0.1s ease;
+}
+
+.filenameButton:hover {
+  text-decoration-color: var(--link-color);
+}
+
+.filenameButtonCopied {
+  color: var(--link-color);
+}
+
+.markdownCopied .filenameButton:hover {
+  text-decoration-color: transparent;
+}
+
+.details {
+  font-size: 12px;
+  color: var(--dimmer-color);
+}

--- a/app/routes/images.tsx
+++ b/app/routes/images.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import type { Route } from "./+types/images";
 import { requireAuth } from "../lib/auth-utils";
+import styles from "./images.module.css";
 
 export async function loader({ context, request }: Route.LoaderArgs) {
   await requireAuth(request);
@@ -83,140 +84,63 @@ export default function Images({ loaderData }: Route.ComponentProps) {
     return new Date(date).toLocaleDateString();
   };
 
+  const markdownCopied = copied?.startsWith("markdown-") ?? false;
+
   return (
-    <main style={{ maxWidth: "1200px", margin: "0 auto", padding: "20px" }}>
-      <div style={{ marginBottom: "40px" }}>
-        <div style={{ marginBottom: "20px" }}>
-          <a
-            href="/blog"
-            style={{ textDecoration: "none", color: "#666", fontSize: "14px" }}
-          >
+    <main className={styles.main}>
+      <div className={styles.header}>
+        <div className={styles.backLinkWrapper}>
+          <a href="/blog" className={styles.backLink}>
             ← Back to blog
           </a>
         </div>
-        <h1 style={{ margin: 0, marginBottom: "10px" }}>Images</h1>
-        <p style={{ margin: 0, color: "#666" }}>
+        <h1 className={styles.title}>Images</h1>
+        <p className={styles.subtitle}>
           Click image to copy URL • Click filename to copy markdown
         </p>
       </div>
 
       {images.length === 0 ? (
-        <p style={{ color: "#666", textAlign: "center", marginTop: "60px" }}>
-          No images uploaded yet.
-        </p>
+        <p className={styles.empty}>No images uploaded yet.</p>
       ) : (
         <div
-          style={{
-            display: "grid",
-            gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))",
-            gap: "30px",
-          }}
+          className={`${styles.grid}${markdownCopied ? ` ${styles.markdownCopied}` : ""}`}
         >
-          {images.map((image) => (
-            <div
-              key={image.key}
-              style={{
-                display: "flex",
-                flexDirection: "column",
-                gap: "10px",
-              }}
-            >
-              <div
-                onClick={() => copyImage(image.url)}
-                style={{
-                  aspectRatio: "1",
-                  borderRadius: "8px",
-                  overflow: "hidden",
-                  cursor: "pointer",
-                  border: "1px solid #e5e5e5",
-                  transition: "transform 0.1s ease",
-                  position: "relative",
-                }}
-                onMouseDown={(e) => {
-                  e.currentTarget.style.transform = "scale(0.98)";
-                }}
-                onMouseUp={(e) => {
-                  e.currentTarget.style.transform = "scale(1)";
-                }}
-                onMouseLeave={(e) => {
-                  e.currentTarget.style.transform = "scale(1)";
-                }}
-              >
-                <img
-                  src={image.url}
-                  alt={image.key}
-                  style={{
-                    width: "100%",
-                    height: "100%",
-                    objectFit: "cover",
-                  }}
-                />
-                {mounted &&
-                  copied ===
-                    `image-${typeof window !== "undefined" ? window.location.origin : ""}${image.url}` && (
-                    <div
-                      style={{
-                        position: "absolute",
-                        top: "50%",
-                        left: "50%",
-                        transform: "translate(-50%, -50%)",
-                        backgroundColor: "rgba(0, 0, 0, 0.8)",
-                        color: "white",
-                        padding: "8px 12px",
-                        borderRadius: "4px",
-                        fontSize: "12px",
-                      }}
-                    >
-                      Copied URL!
-                    </div>
-                  )}
-              </div>
+          {images.map((image) => {
+            const markdownKey = `markdown-![${image.key.replace(/\.[^/.]+$/, "")}](${image.url})`;
+            const imageCopiedKey = `image-${typeof window !== "undefined" ? window.location.origin : ""}${image.url}`;
+            const isMarkdownCopied = copied === markdownKey;
 
-              <div
-                style={{ display: "flex", flexDirection: "column", gap: "4px" }}
-              >
-                <button
-                  onClick={() => copyMarkdown(image.key, image.url)}
-                  style={{
-                    background: "none",
-                    border: "none",
-                    padding: 0,
-                    font: "inherit",
-                    cursor: "pointer",
-                    textAlign: "left",
-                    fontSize: "14px",
-                    fontWeight: "500",
-                    color:
-                      copied ===
-                      `markdown-![${image.key.replace(/\.[^/.]+$/, "")}](${image.url})`
-                        ? "#007acc"
-                        : "#333",
-                    textDecoration: "underline",
-                    textDecorationColor: "transparent",
-                    transition: "all 0.1s ease",
-                  }}
-                  onMouseEnter={(e) => {
-                    if (!copied?.startsWith("markdown-")) {
-                      e.currentTarget.style.textDecorationColor = "#007acc";
-                    }
-                  }}
-                  onMouseLeave={(e) => {
-                    if (!copied?.startsWith("markdown-")) {
-                      e.currentTarget.style.textDecorationColor = "transparent";
-                    }
-                  }}
+            return (
+              <div key={image.key} className={styles.card}>
+                <div
+                  onClick={() => copyImage(image.url)}
+                  className={styles.imageButton}
                 >
-                  {copied ===
-                  `markdown-![${image.key.replace(/\.[^/.]+$/, "")}](${image.url})`
-                    ? "Copied markdown!"
-                    : image.key}
-                </button>
-                <div style={{ fontSize: "12px", color: "#666" }}>
-                  {formatFileSize(image.size)} • {formatDate(image.uploaded)}
+                  <img
+                    src={image.url}
+                    alt={image.key}
+                    className={styles.image}
+                  />
+                  {mounted && copied === imageCopiedKey && (
+                    <div className={styles.copiedOverlay}>Copied URL!</div>
+                  )}
+                </div>
+
+                <div className={styles.meta}>
+                  <button
+                    onClick={() => copyMarkdown(image.key, image.url)}
+                    className={`${styles.filenameButton}${isMarkdownCopied ? ` ${styles.filenameButtonCopied}` : ""}`}
+                  >
+                    {isMarkdownCopied ? "Copied markdown!" : image.key}
+                  </button>
+                  <div className={styles.details}>
+                    {formatFileSize(image.size)} • {formatDate(image.uploaded)}
+                  </div>
                 </div>
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
       )}
     </main>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Migrates the `/images` route from inline styles to a CSS module (`images.module.css`), consistent with other routes like `blog.module.css` and `logout.module.css`.

## Restored style

PR #3 removed an invalid `@media` query from a React `style` object to fix typecheck. This PR restores that responsive behavior in proper CSS:

```css
@media (max-width: 640px) {
  .grid {
    grid-template-columns: 1fr;
    gap: 20px;
  }
}
```

Interactive states (image press scale, filename hover/copied) are now handled with CSS pseudo-classes and conditional classes instead of inline event handlers.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bunx vitest run` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4567e64f-757d-4afe-8e02-4a34bffc14a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4567e64f-757d-4afe-8e02-4a34bffc14a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

